### PR TITLE
Fix serialization type mismatch

### DIFF
--- a/serializers/DragonFruit.Data.Serializers.Html/ApiHtmlSerializer.cs
+++ b/serializers/DragonFruit.Data.Serializers.Html/ApiHtmlSerializer.cs
@@ -10,33 +10,31 @@ namespace DragonFruit.Data.Serializers.Html
         public override string ContentType => "text/html";
         public override bool IsGeneric => false;
 
-        public override HttpContent Serialize<T>(T input)
+        public override HttpContent Serialize(object input)
         {
-            ValidateType<T>();
+            if (!(input is HtmlDocument document))
+            {
+                throw new ArgumentException($"Cannot process {input.GetType().Name}", nameof(input));
+            }
 
             // html is usually larger than 80kb
             var stream = GetStream(true);
-            (input as HtmlDocument)!.Save(stream, Encoding);
+            document.Save(stream, Encoding);
 
             return GetHttpContent(stream);
         }
 
         public override T Deserialize<T>(Stream input)
         {
-            ValidateType<T>();
+            if (typeof(T) != typeof(HtmlDocument))
+            {
+                throw new ArgumentException($"Cannot process {typeof(T).Name}", nameof(T));
+            }
 
             var document = new HtmlDocument();
             document.Load(input, Encoding, AutoDetectEncoding);
 
             return document as T; // where T is validated as a HtmlDocument
-        }
-
-        private static void ValidateType<T>()
-        {
-            if (typeof(T) != typeof(HtmlDocument))
-            {
-                throw new ArgumentException($"Cannot process {typeof(T).Name}", nameof(T));
-            }
         }
 
         /// <summary>

--- a/serializers/DragonFruit.Data.Serializers.Newtonsoft/ApiJsonSerializer.cs
+++ b/serializers/DragonFruit.Data.Serializers.Newtonsoft/ApiJsonSerializer.cs
@@ -21,7 +21,7 @@ namespace DragonFruit.Data.Serializers.Newtonsoft
             set => _serializer = value;
         }
 
-        public override HttpContent Serialize<T>(T input) where T : class
+        public override HttpContent Serialize(object input)
         {
             var stream = GetStream(false);
 

--- a/serializers/DragonFruit.Data.Serializers.SystemJson/ApiSystemTextJsonSerializer.cs
+++ b/serializers/DragonFruit.Data.Serializers.SystemJson/ApiSystemTextJsonSerializer.cs
@@ -28,17 +28,17 @@ namespace DragonFruit.Data.Serializers.SystemJson
             set => _serializerOptions = value;
         }
 
-        public override HttpContent Serialize<T>(T input)
+        public override HttpContent Serialize(object input)
         {
-            var stream = GetStream(false);
-            JsonSerializer.Serialize(stream, input, SerializerOptions);
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(input, input.GetType(), SerializerOptions);
+            var stream = new MemoryStream(bytes);
 
             return GetHttpContent(stream);
         }
 
         public override T Deserialize<T>(Stream input) => JsonSerializer.Deserialize<T>(input, SerializerOptions);
 
-        public Task<T> DeserializeAsync<T>(Stream input) where T : class => JsonSerializer.DeserializeAsync<T>(input, SerializerOptions).AsTask();
+        public ValueTask<T> DeserializeAsync<T>(Stream input) where T : class => JsonSerializer.DeserializeAsync<T>(input, SerializerOptions);
 
         /// <summary>
         /// Registers <see cref="JsonDocument"/> to always use the <see cref="ApiSystemTextJsonSerializer"/>

--- a/src/DragonFruit.Data.csproj
+++ b/src/DragonFruit.Data.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
         <PackageReference Include="System.Buffers" Version="4.5.1" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     </ItemGroup>
 
     <Import Project="$(SolutionDir)res\DragonFruit.Data.props" />

--- a/src/Serializers/ApiSerializer.cs
+++ b/src/Serializers/ApiSerializer.cs
@@ -50,7 +50,7 @@ namespace DragonFruit.Data.Serializers
         /// </summary>
         public bool AutoDetectEncoding { get; set; } = true;
 
-        public abstract HttpContent Serialize<T>(T input) where T : class;
+        public abstract HttpContent Serialize(object input);
         public abstract T Deserialize<T>(Stream input) where T : class;
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace DragonFruit.Data.Serializers
                 return File.Create(Path.GetTempFileName(), 4096, FileOptions.SequentialScan | FileOptions.Asynchronous | FileOptions.DeleteOnClose);
             }
 
-            return new MemoryStream(50000);
+            return new MemoryStream(4096);
         }
 
         /// <summary>

--- a/src/Serializers/ApiXmlSerializer.cs
+++ b/src/Serializers/ApiXmlSerializer.cs
@@ -11,13 +11,13 @@ namespace DragonFruit.Data.Serializers
     {
         public override string ContentType => "application/xml";
 
-        public override HttpContent Serialize<T>(T input) where T : class
+        public override HttpContent Serialize(object input)
         {
             var stream = GetStream(false);
 
             using (var writer = new StreamWriter(stream, Encoding, 4096, true))
             {
-                new XmlSerializer(typeof(T)).Serialize(writer, input);
+                new XmlSerializer(input.GetType()).Serialize(writer, input);
             }
 
             return GetHttpContent(stream);

--- a/src/Serializers/IAsyncSerializer.cs
+++ b/src/Serializers/IAsyncSerializer.cs
@@ -11,6 +11,6 @@ namespace DragonFruit.Data.Serializers
     /// </summary>
     public interface IAsyncSerializer
     {
-        Task<T> DeserializeAsync<T>(Stream input) where T : class;
+        ValueTask<T> DeserializeAsync<T>(Stream input) where T : class;
     }
 }

--- a/src/Serializers/InternalStreamSerializer.cs
+++ b/src/Serializers/InternalStreamSerializer.cs
@@ -12,7 +12,7 @@ namespace DragonFruit.Data.Serializers
     {
         public override string ContentType => "application/octet-stream";
 
-        public async Task<T> DeserializeAsync<T>(Stream input) where T : class
+        public async ValueTask<T> DeserializeAsync<T>(Stream input) where T : class
         {
             var stream = GetStream<T>();
             await input.CopyToAsync(stream).ConfigureAwait(false);
@@ -23,7 +23,7 @@ namespace DragonFruit.Data.Serializers
             return stream as T;
         }
 
-        public override HttpContent Serialize<T>(T input)
+        public override HttpContent Serialize(object input)
         {
             throw new NotSupportedException("Stream serialization is currently one-way");
         }

--- a/tests/DragonFruit.Data.Tests.csproj
+++ b/tests/DragonFruit.Data.Tests.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     </ItemGroup>
 </Project>

--- a/tests/Serializers/SerializerResolverTests.cs
+++ b/tests/Serializers/SerializerResolverTests.cs
@@ -71,7 +71,7 @@ namespace DragonFruit.Data.Tests.Serializers
         public override string ContentType => "nothing";
         public override bool IsGeneric => true;
 
-        public override HttpContent Serialize<T>(T input) where T : class => throw new System.NotImplementedException();
+        public override HttpContent Serialize(object input) => throw new System.NotImplementedException();
 
         public override T Deserialize<T>(Stream input) where T : class => throw new System.NotImplementedException();
     }


### PR DESCRIPTION
As seen [here](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism#serialize-properties-of-derived-classes), the type to serialize needs to be passed in order to get all properties to be serialized.

Also reduces allocations when serializing when using System.Text.Json and reduces the initial MemoryStream array size (from 50kb to 4kb)