### PR TITLE
Make `ValidateRequest(ApiClient)` return a `Task`

### DIFF
--- a/src/ApiClient.cs
+++ b/src/ApiClient.cs
@@ -123,7 +123,6 @@ namespace DragonFruit.Data
             try
             {
                 // send request
-                // ReSharper disable once MethodSupportsCancellation (we need to run regardless of cancellation to release lock)
                 response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token).ConfigureAwait(false);
 
                 // evaluate task status and update monitor
@@ -138,7 +137,6 @@ namespace DragonFruit.Data
                     response?.Dispose();
                 }
 
-                // exit the read lock after fully processing
                 clientLock.Dispose();
             }
         }

--- a/src/ApiClient.cs
+++ b/src/ApiClient.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using DragonFruit.Data.Exceptions;
 using DragonFruit.Data.Headers;
+using DragonFruit.Data.Requests;
 using DragonFruit.Data.Serializers;
 using DragonFruit.Data.Utils;
 using Nito.AsyncEx;
@@ -166,9 +167,17 @@ namespace DragonFruit.Data
         /// <param name="request">The request to validate</param>
         /// <exception cref="NullRequestException">The request can't be performed due to a poorly-formed url</exception>
         /// <exception cref="ClientValidationException">The client can't be used because there is no auth url.</exception>
-        protected virtual void ValidateRequest(ApiRequest request)
+        protected virtual async Task ValidateRequest(ApiRequest request)
         {
-            request.OnRequestExecuting(this);
+            if (request is IRequestExecutingCallback syncCallback)
+            {
+                syncCallback.OnRequestExecuting(this);
+            }
+
+            if (request is IAsyncRequestExecutingCallback asyncCallback)
+            {
+                await asyncCallback.OnRequestExecutingAsync(this).ConfigureAwait(false);
+            }
 
             // note request path is validated on build
             if (request.RequireAuth && string.IsNullOrEmpty(Authorization))
@@ -262,7 +271,7 @@ namespace DragonFruit.Data
         /// </summary>
         /// <remarks>
         /// This should be used when a library needs to enforce a <see cref="DelegatingHandler"/> is wrapped over the <see cref="Handler"/>.
-        /// If overriden, it should be sealed to prevent misuse
+        /// If overriden, the client should be sealed to prevent unintended changes
         /// </remarks>
         protected virtual HttpMessageHandler CreateHandler() => Handler?.Invoke();
 

--- a/src/ApiClient_Async.cs
+++ b/src/ApiClient_Async.cs
@@ -25,10 +25,10 @@ namespace DragonFruit.Data
         /// <summary>
         /// Perform an <see cref="ApiRequest"/> with a specified return type.
         /// </summary>
-        public Task<T> PerformAsync<T>(ApiRequest requestData, CancellationToken token = default) where T : class
+        public async Task<T> PerformAsync<T>(ApiRequest requestData, CancellationToken token = default) where T : class
         {
-            ValidateRequest(requestData);
-            return PerformAsync<T>(requestData.Build(this), token);
+            await ValidateRequest(requestData).ConfigureAwait(false);
+            return await PerformAsync<T>(requestData.Build(this), token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -51,10 +51,10 @@ namespace DragonFruit.Data
         /// <summary>
         /// Perform a <see cref="ApiRequest"/> that returns the response message.
         /// </summary>
-        public Task<HttpResponseMessage> PerformAsync(ApiRequest requestData, CancellationToken token = default)
+        public async Task<HttpResponseMessage> PerformAsync(ApiRequest requestData, CancellationToken token = default)
         {
-            ValidateRequest(requestData);
-            return PerformAsync(requestData.Build(this), token);
+            await ValidateRequest(requestData).ConfigureAwait(false);
+            return await PerformAsync(requestData.Build(this), token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace DragonFruit.Data
         public async Task PerformAsync(ApiFileRequest request, Action<long, long?> progressUpdated = null, CancellationToken token = default)
         {
             // check request data is valid
-            ValidateRequest(request);
+            await ValidateRequest(request).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(request.Destination))
             {

--- a/src/ApiRequest.cs
+++ b/src/ApiRequest.cs
@@ -99,13 +99,6 @@ namespace DragonFruit.Data
         protected virtual IEnumerable<KeyValuePair<string, string>> AdditionalQueries { get; }
 
         /// <summary>
-        /// Overridable method for specifying an action to occur before sending the request to the <see cref="HttpClient"/>
-        /// </summary>
-        protected internal virtual void OnRequestExecuting(ApiClient client)
-        {
-        }
-
-        /// <summary>
         /// Create a <see cref="HttpResponseMessage"/> for this <see cref="ApiRequest"/>, which can then be modified manually or overriden by <see cref="ApiClient.SetupRequest"/>
         /// </summary>
         public HttpRequestMessage Build(ApiClient client)

--- a/src/Requests/IAsyncRequestExecutingCallback.cs
+++ b/src/Requests/IAsyncRequestExecutingCallback.cs
@@ -1,0 +1,20 @@
+﻿// DragonFruit.Data Copyright DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DragonFruit.Data.Requests
+{
+    /// <summary>
+    /// Specifies the <see cref="ApiRequest"/> should have its <see cref="OnRequestExecutingAsync"/> method called after when the request is being executed
+    /// </summary>
+    public interface IAsyncRequestExecutingCallback
+    {
+        /// <summary>
+        /// Overridable method for specifying an action to occur before sending the request to the <see cref="HttpClient"/>.
+        /// Unlike <see cref="IRequestExecutingCallback"/>, this will be run asynchronously and must return a <see cref="ValueTask"/>.
+        /// </summary>
+        ValueTask OnRequestExecutingAsync(ApiClient client);
+    }
+}

--- a/src/Requests/IRequestExecutingCallback.cs
+++ b/src/Requests/IRequestExecutingCallback.cs
@@ -1,0 +1,16 @@
+﻿// DragonFruit.Data Copyright DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+namespace DragonFruit.Data.Requests
+{
+    /// <summary>
+    /// Specifies the <see cref="ApiRequest"/> should have its <see cref="OnRequestExecuting"/> method called after when the request is being executed
+    /// </summary>
+    public interface IRequestExecutingCallback
+    {
+        /// <summary>
+        /// Overridable method for specifying an action to occur before sending the request to the <see cref="HttpClient"/>
+        /// </summary>
+        void OnRequestExecuting(ApiClient client);
+    }
+}

--- a/tests/Requests/RequestFilterTests.cs
+++ b/tests/Requests/RequestFilterTests.cs
@@ -13,8 +13,8 @@ namespace DragonFruit.Data.Tests.Requests
         [Test]
         public void TestFilteredRequests()
         {
-            Assert.Catch<ArgumentException>(() => Client.Perform(new FilteredRequest()));
-            Assert.Catch<ArgumentException>(() => Client.Perform(new InheritedRequest()));
+            Assert.Catch<AggregateException>(() => Client.Perform(new FilteredRequest()));
+            Assert.CatchAsync<ArgumentException>(() => Client.PerformAsync(new InheritedRequest()));
         }
 
         internal class FilteredRequest : ApiRequest, IRequestExecutingCallback

--- a/tests/Requests/RequestFilterTests.cs
+++ b/tests/Requests/RequestFilterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
 using System;
+using DragonFruit.Data.Requests;
 using NUnit.Framework;
 
 namespace DragonFruit.Data.Tests.Requests
@@ -16,11 +17,11 @@ namespace DragonFruit.Data.Tests.Requests
             Assert.Catch<ArgumentException>(() => Client.Perform(new InheritedRequest()));
         }
 
-        internal class FilteredRequest : ApiRequest
+        internal class FilteredRequest : ApiRequest, IRequestExecutingCallback
         {
             public override string Path { get; }
 
-            protected override void OnRequestExecuting(ApiClient client)
+            void IRequestExecutingCallback.OnRequestExecuting(ApiClient client)
             {
                 throw new ArgumentException();
             }


### PR DESCRIPTION
Includes a breaking change resulting in any usage of `OnRequestExecuting` requiring the `ApiRequest` inheriting `IRequestExecutingCallback`